### PR TITLE
Zappmail: Noisy First Steps

### DIFF
--- a/Zapp.xcodeproj/project.pbxproj
+++ b/Zapp.xcodeproj/project.pbxproj
@@ -380,6 +380,7 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Zapp/Zapp-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Frameworks/Pantomime/**";
 				INFOPLIST_FILE = "Zapp/Zapp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
@@ -397,6 +398,7 @@
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Zapp/Zapp-Prefix.pch";
+				HEADER_SEARCH_PATHS = "$(SRCROOT)/Frameworks/Pantomime/**";
 				INFOPLIST_FILE = "Zapp/Zapp-Info.plist";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;

--- a/Zapp.xcodeproj/project.pbxproj
+++ b/Zapp.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2F08D06A143D012C0042B746 /* ZappMessageController.m in Sources */ = {isa = PBXBuildFile; fileRef = 2F08D069143D012B0042B746 /* ZappMessageController.m */; };
 		A83BBA8413FB8ABF002D6310 /* ZappSimulatorController.m in Sources */ = {isa = PBXBuildFile; fileRef = A83BBA8313FB8ABF002D6310 /* ZappSimulatorController.m */; };
 		A846C17014021BD400E5B1B2 /* ZappWebServer.m in Sources */ = {isa = PBXBuildFile; fileRef = A846C16F14021BD400E5B1B2 /* ZappWebServer.m */; };
 		A848E80613ECA621004A55DA /* ZappRepository.m in Sources */ = {isa = PBXBuildFile; fileRef = A848E80513ECA621004A55DA /* ZappRepository.m */; };
@@ -31,6 +32,8 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		2F08D068143D012B0042B746 /* ZappMessageController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZappMessageController.h; sourceTree = "<group>"; };
+		2F08D069143D012B0042B746 /* ZappMessageController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZappMessageController.m; sourceTree = "<group>"; };
 		A82B17CD13EB2583009F0B40 /* iPhoneSimulatorRemoteClient.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = iPhoneSimulatorRemoteClient.h; sourceTree = "<group>"; };
 		A83BBA8213FB8ABF002D6310 /* ZappSimulatorController.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ZappSimulatorController.h; sourceTree = "<group>"; };
 		A83BBA8313FB8ABF002D6310 /* ZappSimulatorController.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ZappSimulatorController.m; sourceTree = "<group>"; };
@@ -191,6 +194,8 @@
 				A83BBA8313FB8ABF002D6310 /* ZappSimulatorController.m */,
 				A8DB670614061E3400149EB8 /* ZappVideoController.h */,
 				A8DB670714061E3400149EB8 /* ZappVideoController.m */,
+				2F08D068143D012B0042B746 /* ZappMessageController.h */,
+				2F08D069143D012B0042B746 /* ZappMessageController.m */,
 			);
 			name = Controller;
 			sourceTree = "<group>";
@@ -274,6 +279,7 @@
 				A83BBA8413FB8ABF002D6310 /* ZappSimulatorController.m in Sources */,
 				A846C17014021BD400E5B1B2 /* ZappWebServer.m in Sources */,
 				A8DB670814061E3400149EB8 /* ZappVideoController.m in Sources */,
+				2F08D06A143D012C0042B746 /* ZappMessageController.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Zapp/Repositories.xcdatamodeld/Repositories.xcdatamodel/contents
+++ b/Zapp/Repositories.xcdatamodeld/Repositories.xcdatamodel/contents
@@ -24,6 +24,6 @@
     </entity>
     <elements>
         <element name="Build" positionX="412" positionY="189" width="128" height="165"/>
-        <element name="Repository" positionX="160" positionY="192" width="128" height="195"/>
+        <element name="Repository" positionX="187" positionY="-54" width="128" height="195"/>
     </elements>
 </model>

--- a/Zapp/ZappAppDelegate.m
+++ b/Zapp/ZappAppDelegate.m
@@ -187,8 +187,7 @@
     [build startWithCompletionBlock:^{
         self.building = NO;
         
-        ZappMessageController *messageController = [ZappMessageController new];
-        [messageController sendMessageForBuild:build];
+        [ZappMessageController sendMessageForBuild:build];
         
         [self pumpBuildQueue];
     }];

--- a/Zapp/ZappAppDelegate.m
+++ b/Zapp/ZappAppDelegate.m
@@ -10,6 +10,7 @@
 #import "ZappAppDelegate.h"
 #import "ZappBackgroundView.h"
 #import "ZappRepositoriesController.h"
+#import "ZappMessageController.h"
 #import "ZappWebServer.h"
 #import "ZappSSHURLFormatter.h"
 #import "iPhoneSimulatorRemoteClient.h"
@@ -185,6 +186,10 @@
     self.building = YES;
     [build startWithCompletionBlock:^{
         self.building = NO;
+        
+        ZappMessageController *messageController = [ZappMessageController new];
+        [messageController sendMessageForBuild:build];
+        
         [self pumpBuildQueue];
     }];
     [self.buildQueue removeObject:build];

--- a/Zapp/ZappBuild.h
+++ b/Zapp/ZappBuild.h
@@ -32,6 +32,7 @@
 @property (nonatomic, readonly) NSString *feedDescription;
 @property (nonatomic, readonly) NSURL *buildLogURL;
 @property (nonatomic, readonly) NSURL *buildVideoURL;
+@property (nonatomic, readonly) NSString *abbreviatedLatestRevision;
 
 - (void)startWithCompletionBlock:(void (^)(void))completionBlock;
 

--- a/Zapp/ZappBuild.h
+++ b/Zapp/ZappBuild.h
@@ -13,6 +13,7 @@
 
 @class ZappRepository;
 
+
 @interface ZappBuild : NSManagedObject
 
 @property (nonatomic, strong) NSString *branch;

--- a/Zapp/ZappBuild.m
+++ b/Zapp/ZappBuild.m
@@ -74,17 +74,8 @@
     [dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
     [dateFormatter setDateStyle:NSDateFormatterMediumStyle];
     
-    NSString *revision = [self.latestRevision substringToIndex:MIN(6, self.latestRevision.length)];
-    
-    NSString *statusDescription = nil;
-    switch (self.status) {
-        case ZappBuildStatusPending: statusDescription = ZappLocalizedString(@"pending"); break;
-        case ZappBuildStatusRunning: statusDescription = ZappLocalizedString(@"running"); break;
-        case ZappBuildStatusFailed: statusDescription = ZappLocalizedString(@"failure"); break;
-        case ZappBuildStatusSucceeded: statusDescription = ZappLocalizedString(@"success"); break;
-        default: break;
-    }
-
+    NSString *revision = self.abbreviatedLatestRevision;
+    NSString *statusDescription = [self.statusDescription lowercaseString];
     
     return [NSString stringWithFormat:@"Built %@ on %@: %@", revision, [dateFormatter stringFromDate:self.startDate], statusDescription];
 }
@@ -100,7 +91,7 @@
     [dateFormatter setTimeStyle:NSDateFormatterMediumStyle];
     [dateFormatter setDateStyle:NSDateFormatterMediumStyle];
     
-    NSString *revision = [self.latestRevision substringToIndex:MIN(6, self.latestRevision.length)];
+    NSString *revision = self.abbreviatedLatestRevision;
     
     if (self.status == ZappBuildStatusPending) {
         return [NSString stringWithFormat:@"%@: %@", self.statusDescription, revision];
@@ -180,6 +171,16 @@
 + (NSSet *)keyPathsForValuesAffectingStatusDescription;
 {
     return [NSSet setWithObject:@"status"];
+}
+
+- (NSString *)abbreviatedLatestRevision;
+{
+    return [self.latestRevision substringToIndex:MIN(6, self.latestRevision.length)];
+}
+
++ (NSSet *)keyPathsForValuesAffectingAbbreviatedLatestRevision;
+{
+    return [NSSet setWithObject:@"latestRevision"];
 }
 
 #pragma mark ZappBuild

--- a/Zapp/ZappBuild.m
+++ b/Zapp/ZappBuild.m
@@ -218,7 +218,7 @@
         BOOL (^runGitCommandWithArguments)(NSArray *) = ^(NSArray *arguments) {
             NSString *errorOutput = nil;
             NSLog(@"running %@ %@", GitCommand, [arguments componentsJoinedByString:@" "]);
-            int exitStatus = [repository runCommandAndWait:GitCommand withArguments:arguments errorOutput:&errorOutput outputBlock:^(NSString *output) {
+            int exitStatus = [repository runCommandAndWait:GitCommand withArguments:arguments standardInput:nil errorOutput:&errorOutput outputBlock:^(NSString *output) {
                 [fileHandle writeData:[output dataUsingEncoding:NSUTF8StringEncoding]];
                 [self appendLogLines:output];
             }];
@@ -236,7 +236,7 @@
         if (!runGitCommandWithArguments([NSArray arrayWithObjects:@"checkout", self.branch, nil])) { return; }
         if (!runGitCommandWithArguments([NSArray arrayWithObjects:@"submodule", @"sync", nil])) { return; }
         if (!runGitCommandWithArguments([NSArray arrayWithObjects:@"submodule", @"update", @"--init", nil])) { return; }
-        [repository runCommandAndWait:GitCommand withArguments:[NSArray arrayWithObjects:@"rev-parse", @"HEAD", nil] errorOutput:&errorOutput outputBlock:^(NSString *output) {
+        [repository runCommandAndWait:GitCommand withArguments:[NSArray arrayWithObjects:@"rev-parse", @"HEAD", nil] standardInput:nil errorOutput:&errorOutput outputBlock:^(NSString *output) {
             [[NSOperationQueue mainQueue] addOperationWithBlock:^() {
                 self.latestRevision = [output stringByTrimmingCharactersInSet:[NSCharacterSet whitespaceAndNewlineCharacterSet]];
             }];
@@ -244,7 +244,7 @@
 
         // Step 2: Build
         NSRegularExpression *appPathRegex = [NSRegularExpression regularExpressionWithPattern:@"^SetMode .+? \"([^\"]+\\.app)\"" options:NSRegularExpressionAnchorsMatchLines error:nil];
-        exitStatus = [repository runCommandAndWait:XcodebuildCommand withArguments:buildArguments errorOutput:&errorOutput outputBlock:^(NSString *output) {
+        exitStatus = [repository runCommandAndWait:XcodebuildCommand withArguments:buildArguments standardInput:nil errorOutput:&errorOutput outputBlock:^(NSString *output) {
             [fileHandle writeData:[output dataUsingEncoding:NSUTF8StringEncoding]];
             [self appendLogLines:output];
             [appPathRegex enumerateMatchesInString:output options:0 range:NSMakeRange(0, output.length) usingBlock:^(NSTextCheckingResult *result, NSMatchingFlags flags, BOOL *stop) {

--- a/Zapp/ZappMessageController.h
+++ b/Zapp/ZappMessageController.h
@@ -10,7 +10,6 @@
 
 @interface ZappMessageController : NSObject
 
-- (void)sendMessageForLatestBuildInRepository:(ZappRepository *)repository;
-- (void)sendMessageForBuild:(ZappBuild *)build;
++ (void)sendMessageForBuild:(ZappBuild *)build;
 
 @end

--- a/Zapp/ZappMessageController.h
+++ b/Zapp/ZappMessageController.h
@@ -1,0 +1,16 @@
+//
+//  ZappMessageController.h
+//  Zapp
+//
+//  Created by Zach Margolis on 10/5/11.
+//  Copyright (c) 2011 Square, Inc. All rights reserved.
+//
+
+#import <Foundation/Foundation.h>
+
+@interface ZappMessageController : NSObject
+
+- (void)sendMessageForLatestBuildInRepository:(ZappRepository *)repository;
+- (void)sendMessageForBuild:(ZappBuild *)build;
+
+@end

--- a/Zapp/ZappMessageController.h
+++ b/Zapp/ZappMessageController.h
@@ -10,6 +10,8 @@
 
 @interface ZappMessageController : NSObject
 
++ (ZappMessageController *)sharedInstance;
+
 - (void)sendMessageForLatestBuildInRepository:(ZappRepository *)repository;
 - (void)sendMessageForBuild:(ZappBuild *)build;
 

--- a/Zapp/ZappMessageController.h
+++ b/Zapp/ZappMessageController.h
@@ -10,8 +10,6 @@
 
 @interface ZappMessageController : NSObject
 
-+ (ZappMessageController *)sharedInstance;
-
 - (void)sendMessageForLatestBuildInRepository:(ZappRepository *)repository;
 - (void)sendMessageForBuild:(ZappBuild *)build;
 

--- a/Zapp/ZappMessageController.m
+++ b/Zapp/ZappMessageController.m
@@ -1,0 +1,22 @@
+//
+//  ZappMessageController.m
+//  Zapp
+//
+//  Created by Zach Margolis on 10/5/11.
+//  Copyright (c) 2011 Square, Inc. All rights reserved.
+//
+
+#import "ZappMessageController.h"
+
+@implementation ZappMessageController
+
+- (void)sendMessageForLatestBuildInRepository:(ZappRepository *)repository;
+{
+    
+}
+
+- (void)sendMessageForBuild:(ZappBuild *)build;
+{
+}
+
+@end

--- a/Zapp/ZappMessageController.m
+++ b/Zapp/ZappMessageController.m
@@ -13,26 +13,16 @@
 
 @interface ZappMessageController ()
 
-- (BOOL)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body error:(out NSError **)error;
+@property (nonatomic, retain) ZappMailConfiguration *mailConfiguration;
+
+- (void)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
 
 @end
 
 
 @implementation ZappMessageController
 
-#pragma mark Initialization
-
-+ (id)sharedInstance;
-{
-    static ZappMessageController *sharedInstance;
-    
-    static dispatch_once_t onceToken;
-    dispatch_once(&onceToken, ^{
-        sharedInstance = [[ZappMessageController alloc] init];
-    });
-    
-    return nil;
-}
+@synthesize mailConfiguration;
 
 #pragma mark Public Methods
 
@@ -43,14 +33,9 @@
 
 - (void)sendMessageForBuild:(ZappBuild *)build;
 {
-    // get the long since the last build
-    // current sha + author
-    
-    NSString *oldRevision = nil;
-    
-    
-    // since last build
+    // get the log since the last build
     // last red red-green or last green-red
+    NSString *oldRevision = nil;
     
     NSString *delta = oldRevision ? [NSString stringWithFormat:@"%@..%@", oldRevision, build.latestRevision] : @"HEAD^..HEAD";
     NSString *format = [NSString stringWithFormat:@"--format=\"%@%%h %%s (%%an)\"", build.repository.remoteURL.absoluteString];
@@ -69,29 +54,14 @@
         
         NSString *message = [[NSArray arrayWithObjects:beginString, latestBuildString, latestBuildStatusString, @"", gitLogOutput, endString, nil] componentsJoinedByString:@"\n"];
         
-        [self sendEmailWithSubject:subject headers:nil body:message error:nil];
-/*
- ===== BEGIN TRANSMISSION =====
- 
- Latest build:
- a895jf9 SUCCESS
- 
- Intermediate commits:
- aaf8d5f Author: Some commit message (8 hours ago)
- 88486a3 Author + Author: Another commit message. (8 days ago)
- 19a938f Author: The same one as before (8 days ago)
- 21ab6e4 Author: A new commit message (8 days ago)
- 
- ====== END TRANSMISSION ======
-*/
+        [self sendEmailWithSubject:subject headers:nil body:message];
     }];
 }
-     
+
 #pragma mark Private Methods
 
-- (BOOL)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body error:(out NSError **)error;
+- (void)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
 {
-    return YES;
 }
      
 @end

--- a/Zapp/ZappMessageController.m
+++ b/Zapp/ZappMessageController.m
@@ -16,16 +16,12 @@ NSString *const SendmailCommand = @"/usr/sbin/sendmail";
 
 @interface ZappMessageController ()
 
-@property (nonatomic, retain) ZappMailConfiguration *mailConfiguration;
-
 - (void)sendEmailFromRepository:(ZappRepository*)repository withSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
 
 @end
 
 
 @implementation ZappMessageController
-
-@synthesize mailConfiguration;
 
 #pragma mark Public Methods
 

--- a/Zapp/ZappMessageController.m
+++ b/Zapp/ZappMessageController.m
@@ -7,8 +7,34 @@
 //
 
 #import "ZappMessageController.h"
+#import "ZappBuild.h"
+#import "ZappRepository.h"
+
+
+@interface ZappMessageController ()
+
+- (BOOL)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body error:(out NSError **)error;
+
+@end
+
 
 @implementation ZappMessageController
+
+#pragma mark Initialization
+
++ (id)sharedInstance;
+{
+    static ZappMessageController *sharedInstance;
+    
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        sharedInstance = [[ZappMessageController alloc] init];
+    });
+    
+    return nil;
+}
+
+#pragma mark Public Methods
 
 - (void)sendMessageForLatestBuildInRepository:(ZappRepository *)repository;
 {
@@ -17,6 +43,55 @@
 
 - (void)sendMessageForBuild:(ZappBuild *)build;
 {
+    // get the long since the last build
+    // current sha + author
+    
+    NSString *oldRevision = nil;
+    
+    
+    // since last build
+    // last red red-green or last green-red
+    
+    NSString *delta = oldRevision ? [NSString stringWithFormat:@"%@..%@", oldRevision, build.latestRevision] : @"HEAD^..HEAD";
+    NSString *format = [NSString stringWithFormat:@"--format=\"%@%%h %%s (%%an)\"", build.repository.remoteURL.absoluteString];
+    
+    NSArray *logCommand = [NSArray arrayWithObjects:GitCommand, @"log", delta, format, nil];
+    
+    [build.repository runCommand:GitCommand withArguments:logCommand completionBlock:^(NSString *gitLogOutput) {
+        
+        NSString *subject = [NSString stringWithFormat:ZappLocalizedString(@"ZAPP: Latest Build %@ %@"), build.abbreviatedLatestRevision, [build.statusDescription uppercaseString]];
+        
+        NSString *beginString = ZappLocalizedString(@"===== BEGIN TRANSMISSION =====");
+        NSString *latestBuildString = ZappLocalizedString(@"Latest build:");
+        NSString *latestBuildStatusString = [NSString stringWithFormat:@"%@ %@", build.abbreviatedLatestRevision, [build.statusDescription uppercaseString]];
+        
+        NSString *endString = ZappLocalizedString(@"====== END TRANSMISSION ======");
+        
+        NSString *message = [[NSArray arrayWithObjects:beginString, latestBuildString, latestBuildStatusString, @"", gitLogOutput, endString, nil] componentsJoinedByString:@"\n"];
+        
+        [self sendEmailWithSubject:subject headers:nil body:message error:nil];
+/*
+ ===== BEGIN TRANSMISSION =====
+ 
+ Latest build:
+ a895jf9 SUCCESS
+ 
+ Intermediate commits:
+ aaf8d5f Author: Some commit message (8 hours ago)
+ 88486a3 Author + Author: Another commit message. (8 days ago)
+ 19a938f Author: The same one as before (8 days ago)
+ 21ab6e4 Author: A new commit message (8 days ago)
+ 
+ ====== END TRANSMISSION ======
+*/
+    }];
 }
+     
+#pragma mark Private Methods
 
+- (BOOL)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body error:(out NSError **)error;
+{
+    return YES;
+}
+     
 @end

--- a/Zapp/ZappMessageController.m
+++ b/Zapp/ZappMessageController.m
@@ -16,7 +16,7 @@ NSString *const SendmailCommand = @"/usr/sbin/sendmail";
 
 @interface ZappMessageController ()
 
-- (void)sendEmailFromRepository:(ZappRepository*)repository withSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
++ (void)sendEmailFromRepository:(ZappRepository*)repository withSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
 
 @end
 
@@ -25,12 +25,7 @@ NSString *const SendmailCommand = @"/usr/sbin/sendmail";
 
 #pragma mark Public Methods
 
-- (void)sendMessageForLatestBuildInRepository:(ZappRepository *)repository;
-{
-    
-}
-
-- (void)sendMessageForBuild:(ZappBuild *)build;
++ (void)sendMessageForBuild:(ZappBuild *)build;
 {
     // get the log since the last build
     // last red red-green or last green-red
@@ -59,7 +54,7 @@ NSString *const SendmailCommand = @"/usr/sbin/sendmail";
 
 #pragma mark Private Methods
 
-- (void)sendEmailFromRepository:(ZappRepository*)repository withSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
++ (void)sendEmailFromRepository:(ZappRepository*)repository withSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
 {
     NSString *subjectHeaderLine = [NSString stringWithFormat:@"Subject: %@", subject];
     // TODO: break headers into key: value lines

--- a/Zapp/ZappMessageController.m
+++ b/Zapp/ZappMessageController.m
@@ -11,11 +11,15 @@
 #import "ZappRepository.h"
 
 
+NSString *const EchoCommand = @"echo";
+NSString *const SendmailCommand = @"sendmail";
+
+
 @interface ZappMessageController ()
 
 @property (nonatomic, retain) ZappMailConfiguration *mailConfiguration;
 
-- (void)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
+- (void)sendEmailFromRepository:(ZappRepository*)repository withSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
 
 @end
 
@@ -54,14 +58,22 @@
         
         NSString *message = [[NSArray arrayWithObjects:beginString, latestBuildString, latestBuildStatusString, @"", gitLogOutput, endString, nil] componentsJoinedByString:@"\n"];
         
-        [self sendEmailWithSubject:subject headers:nil body:message];
+        [self sendEmailFromRepository:build.repository withSubject:subject headers:nil body:message];
     }];
 }
 
 #pragma mark Private Methods
 
-- (void)sendEmailWithSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
+- (void)sendEmailFromRepository:(ZappRepository*)repository withSubject:(NSString *)subject headers:(NSDictionary *)headers body:(NSString *)body;
 {
+    NSString *subjectHeaderLine = [NSString stringWithFormat:@"Subject: %@", subject];
+    NSString *combinedHeadersAndMessage = [[NSArray arrayWithObjects:subjectHeaderLine, body, nil] componentsJoinedByString:@"\n"];
+    
+    NSString *toAddress = @"ios-ci@squareup.com";
+    NSArray *arguments = [NSArray arrayWithObjects:combinedHeadersAndMessage, @"|", SendmailCommand, @"-v", toAddress, nil];
+    [repository runCommand:EchoCommand withArguments:arguments completionBlock:^(NSString *output) {
+        
+    }];
 }
      
 @end

--- a/Zapp/ZappRepository.h
+++ b/Zapp/ZappRepository.h
@@ -43,7 +43,7 @@ extern NSString *const GitFetchSubcommand;
 
 - (ZappBuild *)createNewBuild;
 - (void)runCommand:(NSString *)command withArguments:(NSArray *)arguments completionBlock:(ZappOutputBlock)block;
-- (int)runCommandAndWait:(NSString *)command withArguments:(NSArray *)arguments errorOutput:(NSString **)errorString outputBlock:(void (^)(NSString *))block;
+- (int)runCommandAndWait:(NSString *)command withArguments:(NSArray *)arguments standardInput:(id)standardInput errorOutput:(NSString **)errorString outputBlock:(void (^)(NSString *))block;
 
 @end
 

--- a/Zapp/ZappRepository.h
+++ b/Zapp/ZappRepository.h
@@ -17,6 +17,7 @@ extern NSString *const GitFetchSubcommand;
 
 
 @class ZappBuild;
+@class ZappMailConfiguration;
 
 
 @interface ZappRepository : NSManagedObject

--- a/Zapp/ZappRepository.h
+++ b/Zapp/ZappRepository.h
@@ -17,7 +17,6 @@ extern NSString *const GitFetchSubcommand;
 
 
 @class ZappBuild;
-@class ZappMailConfiguration;
 
 
 @interface ZappRepository : NSManagedObject

--- a/Zapp/ZappRepository.h
+++ b/Zapp/ZappRepository.h
@@ -42,6 +42,7 @@ extern NSString *const GitFetchSubcommand;
 
 - (ZappBuild *)createNewBuild;
 - (void)runCommand:(NSString *)command withArguments:(NSArray *)arguments completionBlock:(ZappOutputBlock)block;
+- (void)runCommand:(NSString *)command withArguments:(NSArray *)arguments standardInput:(id)standardInput completionBlock:(ZappOutputBlock)block;
 - (int)runCommandAndWait:(NSString *)command withArguments:(NSArray *)arguments standardInput:(id)standardInput errorOutput:(NSString **)errorString outputBlock:(void (^)(NSString *))block;
 
 @end

--- a/Zapp/ZappRepository.m
+++ b/Zapp/ZappRepository.m
@@ -265,6 +265,11 @@ NSString *const GitFetchSubcommand = @"fetch";
 
 - (void)runCommand:(NSString *)command withArguments:(NSArray *)arguments completionBlock:(void (^)(NSString *))block;
 {
+    [self runCommand:command withArguments:arguments standardInput:nil completionBlock:block];
+}
+
+- (void)runCommand:(NSString *)command withArguments:(NSArray *)arguments standardInput:(id)standardInput completionBlock:(void (^)(NSString *))block;
+{
     NSAssert([NSThread isMainThread], @"Can only spawn a command from the main thread");
     if (!self.localURL) {
         self.clonedAlready = NO;
@@ -282,7 +287,7 @@ NSString *const GitFetchSubcommand = @"fetch";
         NSString *errorString = nil;
         
         NSMutableString *finalString = [NSMutableString string];
-        [self runCommandAndWait:command withArguments:arguments standardInput:nil errorOutput:&errorString outputBlock:^(NSString *inString) {
+        [self runCommandAndWait:command withArguments:arguments standardInput:standardInput errorOutput:&errorString outputBlock:^(NSString *inString) {
             [finalString appendString:inString];
         }];
         

--- a/Zapp/ZappRepository.m
+++ b/Zapp/ZappRepository.m
@@ -217,7 +217,7 @@ NSString *const GitFetchSubcommand = @"fetch";
     return build;
 }
 
-- (int)runCommandAndWait:(NSString *)command withArguments:(NSArray *)arguments errorOutput:(NSString **)errorString outputBlock:(void (^)(NSString *))block;
+- (int)runCommandAndWait:(NSString *)command withArguments:(NSArray *)arguments standardInput:(id)standardInput errorOutput:(NSString **)errorString outputBlock:(void (^)(NSString *))block;
 {
     NSAssert(![NSThread isMainThread], @"Can only run command and wait from a background thread");
     NSTask *task = [NSTask new];
@@ -234,6 +234,10 @@ NSString *const GitFetchSubcommand = @"fetch";
     [task setLaunchPath:command];
     [task setArguments:arguments];
     [task setCurrentDirectoryPath:self.localURL.path];
+    
+    if (standardInput) {
+        [task setStandardInput:standardInput];
+    }
     
     [task launch];
     
@@ -278,7 +282,7 @@ NSString *const GitFetchSubcommand = @"fetch";
         NSString *errorString = nil;
         
         NSMutableString *finalString = [NSMutableString string];
-        [self runCommandAndWait:command withArguments:arguments errorOutput:&errorString outputBlock:^(NSString *inString) {
+        [self runCommandAndWait:command withArguments:arguments standardInput:nil errorOutput:&errorString outputBlock:^(NSString *inString) {
             [finalString appendString:inString];
         }];
         

--- a/Zapp/main.m
+++ b/Zapp/main.m
@@ -10,5 +10,6 @@
 
 int main(int argc, char *argv[])
 {
+    srand((unsigned int)time(NULL));
     return NSApplicationMain(argc, (const char **)argv);
 }


### PR DESCRIPTION
. @puls

These changes have Zapp send an email to a hardcoded address every time it finishes a build.

The goal is to have fewer emails, and have them be configurable via GUI, but the priority is to actually get Zapp "talking" first. Watch for more pull requests that address these.
