### PR TITLE
Fix a crash that happens when appPath ends up being nil because the regex was too restrictive.

### DIFF
--- a/Zapp/ZappBuild.m
+++ b/Zapp/ZappBuild.m
@@ -254,7 +254,7 @@
 
         // Step 2: Build
         NSArray *buildArguments = [NSArray arrayWithObjects:@"-sdk", @"iphonesimulator", @"-scheme", self.scheme, @"VALID_ARCHS=i386", @"ARCHS=i386", @"ONLY_ACTIVE_ARCH=NO", @"DSTROOT=build", @"install", nil];
-        NSRegularExpression *appPathRegex = [NSRegularExpression regularExpressionWithPattern:@"^SetMode .+? \"([^\"]+\\.app)\"" options:NSRegularExpressionAnchorsMatchLines error:nil];
+        NSRegularExpression *appPathRegex = [NSRegularExpression regularExpressionWithPattern:@"^SetMode .+? ([^\"]+\\.app)" options:NSRegularExpressionAnchorsMatchLines error:nil];
         exitStatus = [repository runCommandAndWait:XcodebuildCommand withArguments:buildArguments standardInput:nil errorOutput:&errorOutput outputBlock:^(NSString *output) {
             [fileHandle writeData:[output dataUsingEncoding:NSUTF8StringEncoding]];
             [self appendLogLines:output];


### PR DESCRIPTION
Zapp was crashing whenever it tried to build my app. It was crashing in `- (void)runSimulatorWithAppPath:(NSString *)appPath initialSkip:(NSInteger)initialSkip failureCount:(NSInteger)initialFailureCount startsWithRetry:(BOOL)startsWithRetry`, because appPath was nil.

It seems the regex being used to find app path is pretty restrictive. I loosened it up a bit, and now things work for me. That said, I'm no regex expert, so maybe there's a better solution that still incorporates the "s.

Here was a sample of my output, for comparison:

```
SetMode u+w,go-w,a+rX build/Applications/Batch.app
    cd /Users/patrick/Batch-ios
    setenv PATH "/Developer/Platforms/iPhoneSimulator.platform/Developer/usr/bin:/Developer/usr/bin:/Developer/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin"
    /bin/chmod -RH u+w,go-w,a+rX /Users/patrick/Batch-ios/build/Applications/Batch.app
```
