### PR TITLE
Buildfixes

### DIFF
--- a/Zapp.xcodeproj/project.pbxproj
+++ b/Zapp.xcodeproj/project.pbxproj
@@ -412,7 +412,7 @@
 				GCC_PREFIX_HEADER = "Zapp/Zapp-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Frameworks/Pantomime/**";
 				INFOPLIST_FILE = "Zapp/Zapp-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = /Applications/XCode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "/Applications/XCode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks /Applications/Xcode.app/Contents/OtherFrameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				WRAPPER_EXTENSION = app;
@@ -432,7 +432,7 @@
 				GCC_PREFIX_HEADER = "Zapp/Zapp-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Frameworks/Pantomime/**";
 				INFOPLIST_FILE = "Zapp/Zapp-Info.plist";
-				LD_RUNPATH_SEARCH_PATHS = /Applications/XCode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
+				LD_RUNPATH_SEARCH_PATHS = "/Applications/XCode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks /Applications/Xcode.app/Contents/OtherFrameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				WRAPPER_EXTENSION = app;

--- a/Zapp.xcodeproj/project.pbxproj
+++ b/Zapp.xcodeproj/project.pbxproj
@@ -236,7 +236,7 @@
 		A8B31D2713E4D610001D593D /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0420;
+				LastUpgradeCheck = 0450;
 				ORGANIZATIONNAME = "Square, Inc";
 			};
 			buildConfigurationList = A8B31D2A13E4D610001D593D /* Build configuration list for PBXProject "Zapp" */;
@@ -403,14 +403,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks,
+					"\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Zapp/Zapp-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Frameworks/Pantomime/**";
 				INFOPLIST_FILE = "Zapp/Zapp-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = /Applications/XCode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				WRAPPER_EXTENSION = app;
@@ -421,14 +423,16 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_OBJC_ARC = YES;
+				COMBINE_HIDPI_IMAGES = YES;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
-					/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks,
+					"\"$(DEVELOPER_DIR)/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks\"",
 				);
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Zapp/Zapp-Prefix.pch";
 				HEADER_SEARCH_PATHS = "$(SRCROOT)/Frameworks/Pantomime/**";
 				INFOPLIST_FILE = "Zapp/Zapp-Info.plist";
+				LD_RUNPATH_SEARCH_PATHS = /Applications/XCode.app/Contents/Developer/Platforms/iPhoneSimulator.platform/Developer/Library/PrivateFrameworks;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				RUN_CLANG_STATIC_ANALYZER = YES;
 				WRAPPER_EXTENSION = app;

--- a/Zapp.xcodeproj/xcshareddata/xcschemes/Zapp.xcscheme
+++ b/Zapp.xcodeproj/xcshareddata/xcschemes/Zapp.xcscheme
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
+   LastUpgradeVersion = "0450"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -22,7 +23,7 @@
       </BuildActionEntries>
    </BuildAction>
    <TestAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
@@ -39,11 +40,12 @@
       </MacroExpansion>
    </TestAction>
    <LaunchAction
-      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.GDB"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.GDB"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       buildConfiguration = "Debug"
+      ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable>

--- a/Zapp/ZappBuild.m
+++ b/Zapp/ZappBuild.m
@@ -18,7 +18,7 @@
 
 @interface ZappBuild ()
 
-@property (nonatomic, strong, readwrite) NSArray logLines;
+@property (nonatomic, strong, readwrite) NSArray *logLines;
 @property (nonatomic, strong) ZappSimulatorController *simulatorController;
 @property (nonatomic, copy) void (^completionBlock)(void);
 @property (nonatomic, strong, readwrite) NSFetchRequest *previousBuildFetchRequest;
@@ -343,7 +343,7 @@
     self.simulatorController.appURL = [self.repository.localURL URLByAppendingPathComponent:appPath];
     self.simulatorController.simulatorOutputPath = self.buildLogURL.path;
     self.simulatorController.videoOutputURL = self.buildVideoURL;
-    self.simulatorController.environment = [NSDictionary dictionaryWithObjectsAndKeys:@"1", @"KIF_AUTORUN", @"1", @"KIF_EXIT_ON_FAILURE", [NSString stringWithFormat:@"%d", lastStartedScenario], @"KIF_INITIAL_SKIP_COUNT", nil];
+    self.simulatorController.environment = [NSDictionary dictionaryWithObjectsAndKeys:@"1", @"KIF_AUTORUN", @"1", @"KIF_EXIT_ON_FAILURE", [NSString stringWithFormat:@"%ld", lastStartedScenario], @"KIF_INITIAL_SKIP_COUNT", nil];
     NSLog(@"starting simulator with skip count of %ld", lastStartedScenario);
     [self.simulatorController launchSessionWithOutputBlock:^(NSString *output, BOOL *stop) {
         [self appendLogLines:output];

--- a/Zapp/ZappRepository.m
+++ b/Zapp/ZappRepository.m
@@ -13,7 +13,7 @@
 
 static NSOperationQueue *ZappRepositoryBackgroundQueue = nil;
 NSString *const GitCommand = @"/usr/bin/git";
-NSString *const XcodebuildCommand = @"/Developer/usr/bin/xcodebuild";
+NSString *const XcodebuildCommand = @"/usr/bin/xcodebuild";
 NSString *const GitFetchSubcommand = @"fetch";
 
 @interface ZappRepository ()

--- a/Zapp/ZappSimulatorController.m
+++ b/Zapp/ZappSimulatorController.m
@@ -47,7 +47,7 @@
 
 - (BOOL)launchSessionWithOutputBlock:(ZappIntermediateOutputBlock)theOutputBlock completionBlock:(ZappResultBlock)theCompletionBlock;
 {
-    NSAssert(![NSThread isMainThread], @"%s called from main thread", _cmd);
+    //NSAssert(![NSThread isMainThread], @"%s called from main thread", _cmd);
     NSString *path = self.appURL.path;
     DTiPhoneSimulatorApplicationSpecifier *specifier = [DTiPhoneSimulatorApplicationSpecifier specifierWithApplicationPath:path];
     if (!specifier) {

--- a/Zapp/en.lproj/MainMenu.xib
+++ b/Zapp/en.lproj/MainMenu.xib
@@ -4085,7 +4085,7 @@
 							<int key="NSNibBindingConnectorVersion">2</int>
 						</object>
 					</object>
-					<int key="connectionID">896</int>
+					<int key="connectionID">874</int>
 				</object>
 				<object class="IBConnectionRecord">
 					<object class="IBBindingConnection" key="connection">


### PR DESCRIPTION
I've tried to update the project so that it builds with the latest version of Xcode (4.5.2). I still have one issue that I'm not sure how to resolve related to MainWindow.xib. Getting the following error:

CompileXIB Zapp/en.lproj/MainMenu.xib
    cd /Users/cwhite/Documents/Square/zapp
    setenv XCODE_DEVELOPER_USR_PATH /Applications/Xcode.app/Contents/Developer/usr/bin/..
    /Applications/Xcode.app/Contents/Developer/usr/bin/ibtool --errors --warnings --notices --output-format human-readable-text --compile /Users/cwhite/Library/Developer/Xcode/DerivedData/Zapp-ezrlixvrxabstbecudtlrsgapaxs/Build/Intermediates/ArchiveIntermediates/Zapp/InstallationBuildProductsLocation/Applications/Zapp.app/Contents/Resources/en.lproj/MainMenu.nib /Users/cwhite/Documents/Square/zapp/Zapp/en.lproj/MainMenu.xib --sdk /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.8.sdk

2012-11-13 11:13:46.096 ibtoold[14091:707] Two members of the document have the object ID 896. This may have happened through an external edit, such as an SCM merge operation.2012-11-13 11:13:46.098 ibtoold[14091:707] Backtrace:  0  0x000000010aff2ba2 -[IBObjectContainer(IBObjectContainerAdditions) verify] (in IDEInterfaceBuilderKi  1  0x000000010afe7afd -[IBObjectContainer initWithCoder:] (in IDEInterfaceBuilderKi  2  0x000000010af9d452 -[IBXMLDecoder deserializeObject:fromElement:] (in IDEInterfaceBuilderKi  3  0x000000010af9df9c __36-[IBXMLDecoder objectForXMLElement:]_block_invoke_0 (in IDEInterfaceBuilderKi  4  0x000000010af9db3b -[IBXMLDecoder invokeRestoringDecodingStack:] (in IDEInterfaceBuilderKi  5  0x000000010af9dd0c -[IBXMLDecoder objectForXMLElement:] (in IDEInterfaceBuilderKi  6  0x000000010af6bed0 -[IBDocument decodeDocumentOfType:withCoder:] (in IDEInterfaceBuilderKi  7  0x000000010d4874b1 -[IBCocoaDocument decodeDocumentOfType:withCoder:] (in IDEInterfaceBuilderCocoaIntegratio  8  0x000000010af6c561 -[IBDocument readFromFileWrapper:ofType:error:] (in IDEInterfaceBuilderKi  9  0x000000010d488a43 -[IBCocoaDocument readFromFileWrapper:ofType:error:] (in IDEInterfaceBuilderCocoaIntegratio 10  0x00007fff8ccd1587 -[NSDocument readFromURL:ofType:error:] (in AppKit 11  0x000000010af67340 __39-[IBDocument readFromURL:ofType:error:]_block_invoke_0 (in IDEInterfaceBuilderKit 12  0x000000010af89653 -[IBDocument invokeWithUndoSuppressed:] (in IDEInterfaceBuilderKit 13  0x000000010af6715e -[IBDocument readFromURL:ofType:error:] (in IDEInterfaceBuilderKit 14  0x000000010ae7e541 (in ibtoold 15  0x000000010ae7b5f9 (in ibtoold 16  0x000000010ae7a0e8 (in ibtoold 17  0x000000010ae79c5f (in ibtoold 18  0x000000010ae79b53 (in ibtoold 19  0x000000010ae86165 (in ibtoold 20  0x000000010ae79684 (in ibtoold 21  0x000000010ae7a8f1 (in ibtoold 22  0x000000010ae78524 (in ibtoold2012-11-13 11:13:46.098 ibtoold[14091:707] Exception raised while decoding document objects - Two members of the document have the object ID 896. This may have happened through an external edit, such as an SCM merge operation./\* com.apple.ibtool.errors */    Failure Reason: Two members of the document have the object ID 896. This may have happened through an external edit, such as an SCM merge operat    Recovery Suggestion: Check the console log for additional informat
